### PR TITLE
Omit the creation of "cvt_label" column from "predict" method of the CVT Model

### DIFF
--- a/upliftml/models/pyspark.py
+++ b/upliftml/models/pyspark.py
@@ -399,9 +399,6 @@ class CVTEstimator:
         """
 
         df_cols = df.columns
-        df = df.withColumn(
-            "cvt_label", F.when(F.col(self.treatment_colname) == F.col(self.target_colname), 1).otherwise(0)
-        )
         df = self.model.transform(df)
         split_udf = udf(lambda value: value[1].item(), FloatType())
         df = df.withColumn("prob", split_udf("probability"))


### PR DESCRIPTION
Removing the line that creates the "cvt_label" column in the "predict" method of the CVT Model as it is not used in this method (I guess it was copied by mistake from the "fit" method) and will eventually prevent the method from being used for the inference stage of an actual machine learning model.